### PR TITLE
Update PLL lock filter thresholds

### DIFF
--- a/econt_sw/configs/startup.yaml
+++ b/econt_sw/configs/startup.yaml
@@ -82,11 +82,11 @@ ECON-T:
       fromMemToLJCDR_enableCapBankOverride:
        param_value: 1
       fromMemToLJCDR_lfLockThrCounter:
-       param_value: 3
+       param_value: 5
       fromMemToLJCDR_lfReLockThrCounter:
-       param_value: 3
+       param_value: 5
       fromMemToLJCDR_lfUnLockThrCounter:
-       param_value: 3
+       param_value: 2
     pll_bytes_24to22:
      params:
       toclkgen_disDES:


### PR DESCRIPTION
Change PLL lock filter thresholds in the startup to make it harder to lock (2**5 BX inst lock status in a row) and easier to unlock (2**2 BX) to make PLL scans more robust.